### PR TITLE
Clean up written files on early exit

### DIFF
--- a/Sources/Runner/main.swift
+++ b/Sources/Runner/main.swift
@@ -42,6 +42,9 @@ proc.waitUntilExit()
 // Pull out the results JSON that the Danger eval should generate
 guard let results = fileManager.contents(atPath: dangerResponsePath) else {
     print("Could not get the results JSON file")
+    // Clean up after ourselves
+    try? fileManager.removeItem(atPath: dslJSONPath)
+    try? fileManager.removeItem(atPath: dangerResponsePath)
     exit(1)
 }
 


### PR DESCRIPTION
I actually managed to fail the build and found the files weren't being clean up :joy:
I didn't abstract it into a function because it affects the flow/readability of the code.