### PR TITLE
Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 ## Build generated
 build/
 DerivedData/
+/*.tar.gz
 
 ## Various settings
 *.pbxuser

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+TOOL_NAME = danger-swift
+VERSION = 0.1.0
+
+PREFIX = /usr/local
+INSTALL_PATH = $(PREFIX)/bin/$(TOOL_NAME)
+BUILD_PATH = .build/release/$(TOOL_NAME)
+TAR_FILENAME = $(TOOL_NAME)-$(VERSION).tar.gz
+
+install: build
+	mkdir -p $(PREFIX)/bin
+	cp -f $(BUILD_PATH) $(INSTALL_PATH)
+
+build:
+	swift package clean
+	swift build --disable-sandbox -c release -Xswiftc -static-stdlib
+
+uninstall:
+	rm -f $(INSTALL_PATH)
+
+get_sha:
+	wget https://github.com/danger/$(TOOL_NAME)/archive/$(VERSION).tar.gz -O $(TAR_FILENAME)
+	shasum -a 256 $(TAR_FILENAME)
+	rm $(TAR_FILENAME)


### PR DESCRIPTION
This PR adds a `Makefile` to build, install and uninstall `danger-swift`. It will not clone or pull sources from GitHub. This `Makefile` will be used for both manual installation and installation via Homebrew.

## Manual Installation
```
$ git clone https://github.com/danger/danger-swift.git
$ cd danger-swift
$ make install
```

## Uninstall
```
$ make uninstall
```
