### PR TITLE
Handle new lib paths from installing via homebrew

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,18 @@
 TOOL_NAME = danger-swift
-VERSION = 0.1.0
+LIB_NAME = libDanger.dylib
+VERSION = 0.1.1
 
 PREFIX = /usr/local
 INSTALL_PATH = $(PREFIX)/bin/$(TOOL_NAME)
 BUILD_PATH = .build/release/$(TOOL_NAME)
+LIB_PATH = .build/release/$(LIB_NAME)
+LIB_INSTALL_PATH = $(PREFIX)/lib/$(LIB_NAME)
 TAR_FILENAME = $(TOOL_NAME)-$(VERSION).tar.gz
 
 install: build
 	mkdir -p $(PREFIX)/bin
 	cp -f $(BUILD_PATH) $(INSTALL_PATH)
+	cp -f $(LIB_PATH) $(LIB_INSTALL_PATH)
 
 build:
 	swift package clean

--- a/Sources/Runner/main.swift
+++ b/Sources/Runner/main.swift
@@ -35,20 +35,26 @@ let libraryFolders = [".build/debug", ".build/release"]
 // e.g "~/.marathon/Scripts/Temp/https:--github.com-danger-danger-swift.git/clone/.build/release"
 let marathonDangerDLDir = NSHomeDirectory() + "/.marathon/Scripts/Temp/"
 let marathonScripts = try? fileManager.contentsOfDirectory(atPath: marathonDangerDLDir)
-var marathonDangerLibPaths: [String] = []
+var depManagerDangerLibPaths: [String] = []
 
 if marathonScripts != nil {
     // TODO: Support running from a fork?
     let dangerSwiftPath = marathonScripts!.first { return $0.contains("danger-swift") }
     if dangerSwiftPath != nil {
         let path = marathonDangerDLDir + dangerSwiftPath! + "/clone/.build/release"
-        marathonDangerLibPaths.append(path)
+        depManagerDangerLibPaths.append(path)
     }
 }
 
+// Was danger-swift installed via homebrew?
+// e.g "/usr/local/Cellar/danger-swift/0.1.0"
+let brewDangerDLDir = "/usr/local/Cellar/danger-swift/"
+let brewScripts = try? fileManager.contentsOfDirectory(atPath: marathonDangerDLDir)
+if marathonScripts != nil { depManagerDangerLibPaths.append("/usr/local/lib") }
+
 // Check and find where we can link to libDanger from
 let libDanger = "libDanger.dylib"
-let libPaths = libraryFolders + marathonDangerLibPaths
+let libPaths = libraryFolders + depManagerDangerLibPaths
 guard let libPath = libPaths.first(where: { fileManager.fileExists(atPath: $0 + "/libDanger.dylib") }) else {
     print("Could not find a libDanger at any of: \(libPaths)")
     exit(1)


### PR DESCRIPTION
After looking at https://github.com/Moya/Moya/pull/1377 I got it working, just needs the paths hooking up.

@eneko's changes installed danger the tool correctly, but doesn't handle the other part - deterministically finding `libDanger.dylib` - this PR _should do that_.