### PR TITLE
Add support for plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install:
   - node -v
   - npm install -g danger
   - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
+  - swiftenv global 4.0
   - swift build 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: trusty
 
 install:
   - node -v
-  - npm install -g danger@alpha
+  - npm install -g danger
   - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
   - swift build 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 * Add your own contributions to the next release on the line below this, please include your name too. Please don't set a new version if you are the first to make the section for `master`.
 
 - Supports the command: `danger-swift edit` to generate an Xcodeproj which you can edit your Dangerfile in with docs etc. - orta
+- Adds plugin infrastructure to `danger-swift`.
+
+  There aren't any plugins yet, but there is infrastructure for them. By suffixing `package: [url]` to any import,
+  you can directly import Swift PM package as a dependency, which is basically how plugins will work.
+
+  So, one of these days:
+
+  ```swift
+  import SwiftLint // package: https://github.com/danger/DangerSwiftLint.git
+
+  SwiftLint.lint(danger)
+  ```
+  
+  - orta
 
 ## 0.2.0
 

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -1,3 +1,5 @@
+import Files // package: https://github.com/JohnSundell/Files.git
+
 import Foundation
 import Danger
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/JohnSundell/Marathon.git",
         "state": {
           "branch": "edit_edit",
-          "revision": "8fdf8014d1ce7fc50ea4b0933d324d6d1366b50d",
+          "revision": "1965af54c186fcdd634d23a0fae2e8625ca5868d",
           "version": null
         }
       },

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ if !changelogChanged && sourceChanges != nil {
 
 
 // You can use these functions to send feedback:
-
 message("Highlight something in the table")
 warn("Something pretty bad, but not important enough to fail the build")
 fail("Something that must be changed")
@@ -34,7 +33,7 @@ In your CI:
 
 ```sh
 # Setup
-npm install -g danger@alpha           # Get DangerJS
+npm install -g danger                 # Get DangerJS
 brew install danger/tap/danger-swift  # Install danger-swift locally
 
 # Script
@@ -63,8 +62,6 @@ make install
 - Add an [API client for GitHub](https://github.com/danger/danger-swift/issues/17)
 - Improve error handling
 - Write docs for end-users with examples
-- Get some other projects using Danger Swift
-- Think about what a plugin infrastructure could look like (e.g. [Danger Swiftlint](https://github.com/ashfurrow/danger-swiftlint))
 - Look into the `Class SwiftObject is implemented in both [x], [y]` runtime error, [probably this](https://bugs.swift.org/browse/SR-1060)
 
 ### Dangerfile.swift
@@ -76,6 +73,19 @@ Setting up:
 1. Edit the dangerfile: `danger-swift edit`.
 
 This will pop up a temporary Xcode project set up for editing a Swift Dangerfile. 
+
+#### Plugins
+
+There aren't any plugins yet, but there is infrastructure for them. By suffixing `package: [url]` to an import,
+you can directly import Swift PM package as a dependency, which is basically how plugins will work.
+
+So, one of these days:
+
+```swift
+import SwiftLint // package: https://github.com/danger/DangerSwiftLint.git
+
+SwiftLint.lint(danger)
+```
 
 #### How it works
 

--- a/Sources/Danger/DangerDSL.swift
+++ b/Sources/Danger/DangerDSL.swift
@@ -5,15 +5,12 @@ import Foundation
 // MARK: - DangerDSL
 
 public struct DSL: Decodable {
-
+    /// The root danger import
     public let danger: DangerDSL
-
 }
 
 public struct DangerDSL: Decodable {
-
     public let git: Git
 
     public let github: GitHub
-
 }

--- a/Sources/Runner/Commands/Edit.swift
+++ b/Sources/Runner/Commands/Edit.swift
@@ -5,27 +5,7 @@ import Danger
 @testable import MarathonCore
 
 func editDanger() throws -> Void {
-    let arguments: [String] = CommandLine.arguments
-    let folderPath = "~/.danger-swift"
-    let printFunction = { print($0) }
-    let vPrintFunction = { (messageExpression: () -> String) in
-        print(messageExpression())
-    }
-
-    let printer = Printer(
-        outputFunction: printFunction,
-        progressFunction: vPrintFunction,
-        verboseFunction: vPrintFunction
-    )
-    let fileSystem = FileSystem()
-
-    let rootFolder = try fileSystem.createFolderIfNeeded(at: folderPath)
-    let packageFolder = try rootFolder.createSubfolderIfNeeded(withName: "Packages")
-    let scriptFolder = try rootFolder.createSubfolderIfNeeded(withName: "Scripts")
-
-    let packageManager = try PackageManager(folder: packageFolder, printer: printer)
-    let scriptManager = try ScriptManager(folder: scriptFolder, packageManager: packageManager, printer: printer)
-
+    
     // Exit if a dangerfile was not found at any supported path
     guard let dangerfilePath = Runtime.getDangerfile() else {
         print("Could not find a Dangerfile")
@@ -39,28 +19,15 @@ func editDanger() throws -> Void {
         exit(1)
     }
 
-    let letAbsoluteLibPath = try Folder(path: libPath).path
+    let absoluteLibPath = try Folder(path: libPath).path
 
+    let arguments = CommandLine.arguments
+    let scriptManager = try getScriptManager()
     let script = try scriptManager.script(atPath: dangerfilePath, allowRemote: true)
     let xcodeprojPath = try script.setupForEdit(arguments: arguments)
 
-// Before:
-//    OTHER_SWIFT_FLAGS = (
-//        "-DXcode",
-//    );
-//
-// After:
-//    OTHER_SWIFT_FLAGS = (
-//        "-I",
-//        "/Users/orta/dev/projects/danger/danger-swift/.build/debug",
-//        "-DXcode",
-//    );
+    // Amends the Xcodeproj to include our build paths
+    try addLibPathToXcodeProj(xcodeprojPath: xcodeprojPath, lib: absoluteLibPath)
 
-//  This is so we can dynamically link the danger library to the runtime generated xcodeproj
-    let pbxproj = try File(path: xcodeprojPath  + "project.pbxproj")
-    let content = try pbxproj.readAsString()
-    let newContent = content.replacingOccurrences(of: "-DXcode\",", with: "-DXcode\", \"-I\", \"\(letAbsoluteLibPath)\"")
-    
-    try pbxproj.write(string:newContent)
     try script.watch(arguments: arguments)
 }

--- a/Sources/Runner/EditXcodeProj.swift
+++ b/Sources/Runner/EditXcodeProj.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Files
+
+/// Before:
+///    OTHER_SWIFT_FLAGS = (
+///        "-DXcode",
+///    );
+///
+/// After:
+///    OTHER_SWIFT_FLAGS = (
+///        "-I",
+///        "/Users/orta/dev/projects/danger/danger-swift/.build/debug",
+///        "-L",
+///        "/Users/orta/dev/projects/danger/danger-swift/.build/debug",
+///        "-DXcode",
+///    );
+///
+
+func addLibPathToXcodeProj(xcodeprojPath: String, lib: String) throws -> Void {
+    let pbxproj = try File(path: xcodeprojPath  + "project.pbxproj")
+    let content = try pbxproj.readAsString()
+    let before = "-DXcode\","
+    let after = "-DXcode\", \"-I\", \"\(lib)\", \"-L\", \"\(lib)\""
+    let newContent = content.replacingOccurrences(of: before, with: after)
+
+    try pbxproj.write(string:newContent)
+}

--- a/Sources/Runner/MarathonScriptManager.swift
+++ b/Sources/Runner/MarathonScriptManager.swift
@@ -1,0 +1,26 @@
+import Files
+@testable import MarathonCore
+
+func getScriptManager() throws -> ScriptManager {
+    let folderPath = "~/.danger-swift"
+    let printFunction = { print($0) }
+    let vPrintFunction = { (messageExpression: () -> String) in
+        print(messageExpression())
+    }
+    
+    let printer = Printer(
+        outputFunction: printFunction,
+        progressFunction: vPrintFunction,
+        verboseFunction: vPrintFunction
+    )
+    let fileSystem = FileSystem()
+    
+    let rootFolder = try fileSystem.createFolderIfNeeded(at: folderPath)
+    let packageFolder = try rootFolder.createSubfolderIfNeeded(withName: "Packages")
+    let scriptFolder = try rootFolder.createSubfolderIfNeeded(withName: "Scripts")
+    
+    let packageManager = try PackageManager(folder: packageFolder, printer: printer)
+    let config = ScriptManager.Config(prefix: "package: ", file: "Dangerplugins")
+
+    return try ScriptManager(folder: scriptFolder, packageManager: packageManager, printer: printer, config: config)
+}

--- a/Sources/Runner/MarathonScriptManager.swift
+++ b/Sources/Runner/MarathonScriptManager.swift
@@ -2,7 +2,7 @@ import Files
 @testable import MarathonCore
 
 func getScriptManager() throws -> ScriptManager {
-    let folder = try Folder.temporary.createSubfolder(named: ".danger-swift")
+    let folder = "~/.danger-swift"
     let printFunction = { print($0) }
     let vPrintFunction = { (messageExpression: () -> String) in
         print(messageExpression())
@@ -15,7 +15,7 @@ func getScriptManager() throws -> ScriptManager {
     )
     let fileSystem = FileSystem()
     
-    let rootFolder = try fileSystem.createFolderIfNeeded(at: folder.path)
+    let rootFolder = try fileSystem.createFolderIfNeeded(at: folder)
     let packageFolder = try rootFolder.createSubfolderIfNeeded(withName: "Packages")
     let scriptFolder = try rootFolder.createSubfolderIfNeeded(withName: "Scripts")
     

--- a/Sources/Runner/MarathonScriptManager.swift
+++ b/Sources/Runner/MarathonScriptManager.swift
@@ -2,7 +2,7 @@ import Files
 @testable import MarathonCore
 
 func getScriptManager() throws -> ScriptManager {
-    let folderPath = "~/.danger-swift"
+    let folder = try Folder.temporary.createSubfolder(named: ".danger-swift")
     let printFunction = { print($0) }
     let vPrintFunction = { (messageExpression: () -> String) in
         print(messageExpression())
@@ -15,7 +15,7 @@ func getScriptManager() throws -> ScriptManager {
     )
     let fileSystem = FileSystem()
     
-    let rootFolder = try fileSystem.createFolderIfNeeded(at: folderPath)
+    let rootFolder = try fileSystem.createFolderIfNeeded(at: folder.path)
     let packageFolder = try rootFolder.createSubfolderIfNeeded(withName: "Packages")
     let scriptFolder = try rootFolder.createSubfolderIfNeeded(withName: "Scripts")
     

--- a/Sources/Runner/main.swift
+++ b/Sources/Runner/main.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 let cliLength = ProcessInfo.processInfo.arguments.count
-print(ProcessInfo.processInfo.arguments)
+
 if cliLength > 1 && "edit" == CommandLine.arguments[1] {
     try editDanger()
 } else {
-    runDanger()
+    try runDanger()
 }

--- a/Sources/Runner/main.swift
+++ b/Sources/Runner/main.swift
@@ -1,9 +1,12 @@
 import Foundation
 
 let cliLength = ProcessInfo.processInfo.arguments.count
-
-if cliLength > 1 && "edit" == CommandLine.arguments[1] {
-    try editDanger()
-} else {
-    try runDanger()
+do {
+    if cliLength > 1 && "edit" == CommandLine.arguments[1] {
+        try editDanger()
+    } else {
+        try runDanger()
+    }
+} catch {
+    exit(1)
 }


### PR DESCRIPTION
Uses Marathon to download and setup any required dependencies, which is basically the infra for plugins. It will then hook up the dependencies at runtime at the same way that libDanger is hooked up.

Requires on https://github.com/JohnSundell/Marathon/pull/148 