### PR TITLE
Remove testable and use a marathon release branch

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,9 +14,9 @@
         "package": "Marathon",
         "repositoryURL": "https://github.com/JohnSundell/Marathon.git",
         "state": {
-          "branch": "edit_edit",
-          "revision": "1965af54c186fcdd634d23a0fae2e8625ca5868d",
-          "version": null
+          "branch": null,
+          "revision": "5bd186ec7a78f3c978ce72041aa9bea006868454",
+          "version": "2.0.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .executable(name: "danger-swift", targets: ["Runner"])
     ],
     dependencies: [
-        .package(url: "https://github.com/JohnSundell/Marathon.git", .branch("edit_edit")),
+        .package(url: "https://github.com/JohnSundell/Marathon.git", from: "2.0.1"),
     ],
     targets: [
         .target(name: "Danger", dependencies: []),

--- a/Sources/Runner/Commands/Edit.swift
+++ b/Sources/Runner/Commands/Edit.swift
@@ -1,8 +1,8 @@
 import Foundation
-import Files
 import Danger
 
-@testable import MarathonCore
+import Files
+import MarathonCore
 
 func editDanger() throws -> Void {
     

--- a/Sources/Runner/Commands/Runner.swift
+++ b/Sources/Runner/Commands/Runner.swift
@@ -2,7 +2,7 @@ import Foundation
 import Danger
 
 import Files
-@testable import MarathonCore
+import MarathonCore
 
 func runDanger() throws -> Void {
     // Pull in the JSON from Danger JS

--- a/Sources/Runner/MarathonScriptManager.swift
+++ b/Sources/Runner/MarathonScriptManager.swift
@@ -1,5 +1,5 @@
 import Files
-@testable import MarathonCore
+import MarathonCore
 
 func getScriptManager() throws -> ScriptManager {
     let folder = "~/.danger-swift"


### PR DESCRIPTION
With https://github.com/JohnSundell/Marathon/pull/149 and https://github.com/JohnSundell/Marathon/releases/tag/2.0.1 - I've shipped a release build that means Danger Swift can go out.