### PR TITLE
Generate Dangerfile for edit command when it DNE

### DIFF
--- a/Sources/Runner/Commands/Edit.swift
+++ b/Sources/Runner/Commands/Edit.swift
@@ -5,13 +5,20 @@ import Files
 import MarathonCore
 
 func editDanger() throws -> Void {
-    
-    // Exit if a dangerfile was not found at any supported path
-    guard let dangerfilePath = Runtime.getDangerfile() else {
-        print("Could not find a Dangerfile")
-        print("Please use a supported path: \(Runtime.supportedPaths)")
-        exit(1)
+
+    let createDangerfile = { () -> String in
+        do {
+            let template = "import Danger \n let danger = Danger()"
+            let data = template.data(using: .utf8)!
+            return try FileSystem().createFile(at: "Dangerfile.swift", contents: data).path
+        } catch {
+            print("Could not find or generate a Dangerfile")
+            exit(1)
+        }
     }
+
+    // If dangerfile was not found, attempt to create one at Dangerfile.swift
+    let dangerfilePath = Runtime.getDangerfile() ?? createDangerfile()
 
     guard let libPath = Runtime.getLibDangerPath() else {
         print("Could not find a libDanger to link against at any of: \(Runtime.potentialLibraryFolders)")


### PR DESCRIPTION
This could possibly resolve #38.

When generating the Dangerfile I added the boiler plate template:
```Swift
import Danger

let danger = Danger()
```

Also, question about the new DSL. The test JSON in [fixtures/eidolon_609.json](https://github.com/danger/danger-swift/blob/master/fixtures/eidolon_609.json) has `danger` double nested. 

Does the accurately DSL represent this? I had trouble evaluating with the commands on README 😕 