### PR TITLE
Links against library generated from Marathon dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add your own contributions to the next release on the line below this, please include your name too. Please don't set
   a new version if you are the first to make the section for `master`.
+* Adds linker flag to link against Marathon dependencies. See https://github.com/JohnSundell/Marathon/pull/153.
 
 ## 0.3.0
 

--- a/Sources/Runner/Commands/Runner.swift
+++ b/Sources/Runner/Commands/Runner.swift
@@ -59,6 +59,7 @@ func runDanger() throws -> Void {
         if marathonLibPath != nil {
             libArgs += ["-L", marathonPath + marathonLibPath!]
             libArgs += ["-I", marathonPath + marathonLibPath!]
+            libArgs += ["-lMarathonDependencies"]
         }
     }
 


### PR DESCRIPTION
This is a follow-up from https://github.com/JohnSundell/Marathon/pull/153, which added generated libraries for dependencies resolved by Marathon. I have verified that this works locally. 