### PR TITLE
Fix cli arguments

### DIFF
--- a/Sources/Danger/Danger.swift
+++ b/Sources/Danger/Danger.swift
@@ -21,11 +21,11 @@ private final class DangerRunner {
         let isVerbose = CommandLine.arguments.contains("--verbose")
         let isSilent = CommandLine.arguments.contains("--silent")
         logger = Logger(isVerbose: isVerbose, isSilent: isSilent)
-
         logger.logInfo("Ran with: \(CommandLine.arguments.joined(separator: " "))")
-
-        let dslJSONArg: String? = CommandLine.arguments[1]
-        let outputJSONPath = CommandLine.arguments[2]
+        
+        let cliLength = CommandLine.arguments.count
+        let dslJSONArg: String? = CommandLine.arguments[cliLength - 2]
+        let outputJSONPath = CommandLine.arguments[cliLength - 1]
 
         guard let dslJSONPath = dslJSONArg else {
             logger.logError("could not find DSL JSON arg")


### PR DESCRIPTION
Fixes #54. 

"ERROR: could not find DSL JSON at path: -frontend" meant that Danger picked wrong argument for DSL JSON path, after this change it started working again (see [Harvey#115](https://circleci.com/gh/Moya/Harvey/115))