### PR TITLE
Reordering how Runner args are routed to Danger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## Master
 
+* Reordering how Runner args are routed to Danger - rockbruno
+
 ## 0.3.3
 
 * Fixes for the CLI arg order from danger-js - sunshinejr

--- a/Sources/Runner/Commands/Runner.swift
+++ b/Sources/Runner/Commands/Runner.swift
@@ -84,9 +84,9 @@ func runDanger(logger: Logger) throws -> Void {
     args += ["-lDanger"] // Eval the code with the Target Danger added
     args += libArgs
     args += [dangerfilePath] // The Dangerfile
+    args += Array(CommandLine.arguments.dropFirst()) // Arguments sent to Danger
     args += [dslJSONPath] // The DSL for a Dangerfile from DangerJS
     args += [dangerResponsePath] // The expected for a Dangerfile from DangerJS
-    args += Array(CommandLine.arguments.dropFirst())
 
     // This ain't optimal, but SwiftPM have _so much code_ around this.
     // So maybe there's a better way


### PR DESCRIPTION
It seems like Marathon's number of arguments cannot be predicted, which caused https://github.com/danger/danger-swift/issues/54 😫 

The reverting PR https://github.com/danger/danger-swift/pull/55 fixes the issue, but also makes `--verbose` and his friends stop working.

It seems that injecting the arguments right after the Dangerfile will hopefully fix this once and for all. Since we only check the last arguments, hopefully injecting them in the middle will not cause issues. We can also drop logging entirely from the second part if it makes more sense, so we won't have to do this weird arg routing thing.

@sunshinejr If possible, could you help me test this? I think you have a setup where Marathon ends up with different arguments than me, which would be a way to confirm that this won't break things again