### PR TITLE
[DONE] linux support for make install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,29 @@
-os: linux
 language: generic
-sudo: required
-dist: trusty
-
-install:
-  - node -v
-  - npm install -g danger
-  - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
-  - swiftenv global 4.0
-  - swift build 
-
-script:
-  - swift test
-  - danger process .build/x86_64-unknown-linux/debug/danger-swift
-  - sudo chmod -R a+rwx /usr/local/
-  - make install
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode9.2
+      install:
+        - node -v
+        - npm install -g danger
+        - swift build 
+      script:
+        - swift test
+        - danger process .build/x86_64-unknown-linux/debug/danger-swift
+        - sudo chmod -R a+rwx /usr/local/
+        - make install
+    - os: linux
+      language: generic
+      sudo: required
+      dist: trusty
+      install:
+        - node -v
+        - npm install -g danger
+        - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
+        - swiftenv global 4.0
+        - swift build 
+      script:
+        - swift test
+        - danger process .build/x86_64-apple-macosx10.10/debug/danger-swift
+        - sudo chmod -R a+rwx /usr/local/
+        - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,5 @@ install:
 script:
   - swift test
   - danger process .build/x86_64-unknown-linux/debug/danger-swift
+  - sudo chmod -R a+rwx /usr/local/
   - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ install:
 script:
   - swift test
   - danger process .build/x86_64-unknown-linux/debug/danger-swift
+  - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
         - swift build 
       script:
         - swift test
-        - danger process .build/x86_64-unknown-linux/debug/danger-swift
+        - danger process .build/x86_64-apple-macosx10.10/debug/danger-swift
         - sudo chmod -R a+rwx /usr/local/
         - make install
     - os: linux
@@ -24,6 +24,6 @@ matrix:
         - swift build 
       script:
         - swift test
-        - danger process .build/x86_64-apple-macosx10.10/debug/danger-swift
+        - danger process .build/x86_64-unknown-linux/debug/danger-swift
         - sudo chmod -R a+rwx /usr/local/
         - make install

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -26,5 +26,3 @@ if !isTrivial && !changelogChanged && sourceChanges != nil {
 if danger.github.pullRequest.title.contains("WIP") {
     warn("PR is classed as Work in Progress")
 }
-
-message("It works!")

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -26,3 +26,5 @@ if !isTrivial && !changelogChanged && sourceChanges != nil {
 if danger.github.pullRequest.title.contains("WIP") {
     warn("PR is classed as Work in Progress")
 }
+
+message("It works!")

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BUILD_PATH = .build/release/$(TOOL_NAME)
 LIB_INSTALL_PATH = $(PREFIX)/lib/danger
 TAR_FILENAME = $(TOOL_NAME)-$(VERSION).tar.gz
 
-SWIFT_LIB_FILES = .build/release/libDanger.dylib .build/release/Danger.swiftdoc .build/release/Danger.swiftmodule
+SWIFT_LIB_FILES = .build/release/libDanger.* .build/release/Danger.swiftdoc .build/release/Danger.swiftmodule
 
 install: build
 	mkdir -p $(PREFIX)/bin
@@ -18,7 +18,7 @@ install: build
 
 build:
 	swift package clean
-	swift build --disable-sandbox -c release -Xswiftc -static-stdlib
+	swift build --disable-sandbox -c release --static-swift-stdlib
 
 uninstall:
 	rm -f $(INSTALL_PATH)


### PR DESCRIPTION
This pull request makes the manual install work on both macOS and linux

```
git clone https://github.com/danger/danger-swift.git
cd danger-swift
make install
```

- `make install` is run as a part of the CI process to make sure it works
- travis now runs tests on both linux and macOS