### PR TITLE
Make repository description optional

### DIFF
--- a/Sources/Danger/GitHubDSL.swift
+++ b/Sources/Danger/GitHubDSL.swift
@@ -276,7 +276,7 @@ public struct GitHubRepo: Decodable {
     public let isPrivate: Bool
 
     /// A textual description of the repo.
-    public let description: String
+    public let description: String?
 
     /// A boolean stating whether the repo is a fork.
     public let isFork: Bool


### PR DESCRIPTION
If description of repository was not set, danger-swift had always been failing to parse input from danger-js.