### PR TITLE
Make commit author and committer optional

### DIFF
--- a/Sources/Danger/GitHubDSL.swift
+++ b/Sources/Danger/GitHubDSL.swift
@@ -344,7 +344,7 @@ public struct GitHubCommit: Decodable {
     public let url: String
 
     /// The GitHub user who wrote the code.
-    public let author: GitHubUser
+    public let author: GitHubUser?
 
     /// The GitHub user who shipped the code.
     public let committer: GitHubUser

--- a/Sources/Danger/GitHubDSL.swift
+++ b/Sources/Danger/GitHubDSL.swift
@@ -347,7 +347,7 @@ public struct GitHubCommit: Decodable {
     public let author: GitHubUser?
 
     /// The GitHub user who shipped the code.
-    public let committer: GitHubUser
+    public let committer: GitHubUser?
 
 }
 


### PR DESCRIPTION
Noticed that in some cases commits may loose author (when they pushed with the wrong email, for example).

had this in commits response and danger-swift failed to parse it:
```json
{
    "sha": "124c29519f7bf5427f7898c321dad561e2443f36",
    "commit": {
      "author": {
        "name": "User",
        "email": "user@mail.com",
        "date": "2018-05-08T08:22:20Z"
      },
      "committer": {
        "name": "User",
        "email": "user@mail.com",
        "date": "2018-05-08T08:22:20Z"
      },
      "message": "...",
      "tree": {
        "sha": "206f9b31716726968de6a35c2ee19a1ada62e8e5",
        "url": "https://api.github.com/repos/company/repo/git/trees/206f9b31716726968de6a35c2ee19a1ada62e8e5"
      },
      "url": "https://api.github.com/repos/company/repo/git/commits/124c29519f7bf5427f7898c321dad561e2443f36",
      "comment_count": 0,
      "verification": {
        "verified": false,
        "reason": "unsigned",
        "signature": null,
        "payload": null
      }
    },
    "url": "https://api.github.com/repos/company/repo/commits/124c29519f7bf5427f7898c321dad561e2443f36",
    "html_url": "https://github.com/company/repo/commit/124c29519f7bf5427f7898c321dad561e2443f36",
    "comments_url": "https://api.github.com/repos/company/repo/commits/124c29519f7bf5427f7898c321dad561e2443f36/comments",
    "author": null,
    "committer": null,
    "parents": [
      {
        "sha": "9ecf478dbc6c95e2001642cc988b4e64eb4cea72",
        "url": "https://api.github.com/repos/company/repo/commits/9ecf478dbc6c95e2001642cc988b4e64eb4cea72",
        "html_url": "https://github.com/company/repo/commit/9ecf478dbc6c95e2001642cc988b4e64eb4cea72"
      }
    ]
  }
```
Just like #73 it's somehow related to #68 :)

