### PR TITLE
Missing initialization of Danger

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ You can make a Dangerfile that looks through PR metadata, it's fully typed.
 ```swift
 import Danger
 
+let danger = Danger()
 let allSourceFiles = danger.git.modifiedFiles + danger.git.createdFiles
 
 let changelogChanged = allSourceFiles.contains("CHANGELOG.md")


### PR DESCRIPTION
When trying danger swift out, I got the error `Dangerfile.swift:4:28: error: use of unresolved identifier 'danger'`.

After a brief look into you [`Dangerfile.swift`](https://github.com/danger/danger-swift/blob/master/Dangerfile.swift#L6) I saw the example was wrong/outdated.