### PR TITLE
[BitbucketServer] Make description, commiter and committerTimestamp optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 
 * Remove Sourcery-based code generation in favor of Swift 4.1's native Equatable conformance generation - yhkaplan
 
+### Changed
+* [BitbucketServer] Make description, commiter and committerTimestamp optional. [#79](https://github.com/danger/danger-swift/pull/79) by [@acecilia](https://github.com/acecilia)
+* [Github] Make repository description optional. [#73](https://github.com/danger/danger-swift/pull/73) by [@hiragram](https://github.com/hiragram)
+* [Github] Make commit author and committer optional. [#75](https://github.com/danger/danger-swift/pull/75) by [@Sega-Zero](https://github.com/Sega-Zero)
+
 ## 0.4.0
 
 * Add Support for Bitbucket Server - thomasraith

--- a/Sources/Danger/BitBucketServerDSL.swift
+++ b/Sources/Danger/BitBucketServerDSL.swift
@@ -240,16 +240,16 @@ public struct BitBucketServerCommit: Decodable, Equatable {
     public let displayId: String
     
     /// The author of the commit, assumed to be the person who wrote the code.
-    public let author: BitBucketServerUser
+    public let author: BitBucketServerUser?
     
     /// The UNIX timestamp for when the commit was authored
     public let authorTimestamp: Int
     
     /// The author of the commit, assumed to be the person who commited/merged the code into a project.
-    public let committer: BitBucketServerUser
+    public let committer: BitBucketServerUser?
     
     /// When the commit was commited to the project
-    public let committerTimestamp: Int
+    public let committerTimestamp: Int?
     
     /// The commit's message
     public let message: String
@@ -309,8 +309,8 @@ public struct BitBucketServerPR: Decodable, Equatable {
     /// Title of the pull request.
     public let title: String
     
-    /// The creator of the PR
-    public let description: String
+    /// The description of the PR
+    public let description: String?
     
     /// The pull request's current status.
     public let state: String

--- a/Sources/Danger/BitBucketServerDSL.swift
+++ b/Sources/Danger/BitBucketServerDSL.swift
@@ -240,7 +240,7 @@ public struct BitBucketServerCommit: Decodable, Equatable {
     public let displayId: String
     
     /// The author of the commit, assumed to be the person who wrote the code.
-    public let author: BitBucketServerUser?
+    public let author: BitBucketServerUser
     
     /// The UNIX timestamp for when the commit was authored
     public let authorTimestamp: Int


### PR DESCRIPTION
Following implementation in https://github.com/danger/danger-swift/pull/75 and https://github.com/danger/danger-swift/pull/73