### PR TITLE
Add filetype extensions to modifiedFiles, createdFiles, and deletedFiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,8 @@
 
 ## Master
 
-## 0.4.1
-
-* Remove Sourcery-based code generation in favor of Swift 4.1's native Equatable conformance generation - yhkaplan
+* Change modifiedFiles, createdFiles, deletedFiles to be of type `File`, adding Name and FileType properties - [#80](https://github.com/danger/danger-swift/pull/80) by [yhkaplan](https://github.com/yhkaplan)
+* Remove Sourcery-based code generation in favor of Swift 4.1's native Equatable conformance generation - [#78](https://github.com/danger/danger-swift/pull/78) by [yhkaplan](https://github.com/yhkaplan)
 
 ### Changed
 * [BitbucketServer] Make description, commiter and committerTimestamp optional. [#79](https://github.com/danger/danger-swift/pull/79) by [@acecilia](https://github.com/acecilia)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## Master
 
-* Change modifiedFiles, createdFiles, deletedFiles to be of type `File`, adding Name and FileType properties - [#80](https://github.com/danger/danger-swift/pull/80) by [yhkaplan](https://github.com/yhkaplan)
+* Change modifiedFiles, createdFiles, deletedFiles to be of type `File`, adding Name and FileType properties - [#81](https://github.com/danger/danger-swift/pull/81) by [yhkaplan](https://github.com/yhkaplan)
 * Remove Sourcery-based code generation in favor of Swift 4.1's native Equatable conformance generation - [#78](https://github.com/danger/danger-swift/pull/78) by [yhkaplan](https://github.com/yhkaplan)
 
 ### Changed

--- a/Sources/Danger/Extensions/NSRegularExpressionExtensions.swift
+++ b/Sources/Danger/Extensions/NSRegularExpressionExtensions.swift
@@ -1,0 +1,19 @@
+
+import Foundation
+
+extension NSRegularExpression {
+ 
+    func firstMatchingString(in string: String) -> String? {
+        let searchRange = NSRange(location: 0, length: string.count)
+        
+        guard
+            let match = firstMatch(in: string, options: [], range: searchRange),
+            let matchRange = Range(match.range, in: string)
+        else {
+            return nil
+        }
+        
+        return String(string[matchRange])
+    }
+    
+}

--- a/Sources/Danger/File.swift
+++ b/Sources/Danger/File.swift
@@ -36,7 +36,7 @@ extension FileType {
         return rawValue
     }
 
-    public init?(from file: File) {
+    init?(from file: File) {
         let allCasesDelimited = FileType.allCases.map { $0.extension }.joined(separator: "|")
 
         guard

--- a/Sources/Danger/File.swift
+++ b/Sources/Danger/File.swift
@@ -28,7 +28,7 @@ public enum FileType: String, Equatable {
     }
 }
 
-// MARK: - Public extensions
+// MARK: - FileType extensions
 
 extension FileType {
 

--- a/Sources/Danger/File.swift
+++ b/Sources/Danger/File.swift
@@ -35,16 +35,13 @@ extension FileType {
     public init?(from fileName: String) {
         let allCasesDelimited = FileType.allCases.map { $0.extension }.joined(separator: "|")
 
-        // TODO: move ugly regex stuff to tested extension where it belongs, write tests
         guard
-            let regex = try? NSRegularExpression(pattern: "\\.(\(allCasesDelimited))$", options: []),
-            let match = regex.firstMatch(in: fileName, options: [], range: NSRange(location: 0, length: fileName.count)),
-            let range = Range(match.range, in: fileName)
+            let pattern = try? NSRegularExpression(pattern: "\\.(\(allCasesDelimited))$"),
+            let rawValue = pattern.firstMatchingString(in: fileName)
         else {
             return nil
         }
 
-        let rawValue = String(fileName[range])
         self.init(rawValue: rawValue)
     }
 

--- a/Sources/Danger/File.swift
+++ b/Sources/Danger/File.swift
@@ -20,11 +20,11 @@ extension File {
 // MARK: - FileType
 
 public enum FileType: String, Equatable {
-    case h, json, m, markdown = "md", pbxproj, plist, storyboard, swift
+    case h, json, m, markdown = "md", mm, pbxproj, plist, storyboard, swift, xcscheme, yaml, yml
 
     @available(swift, deprecated: 4.2, message: "Replace with CaseIterable conformance")
     static internal var allCases: [FileType] {
-        return [.h, .json, .m, .markdown, .pbxproj, .plist, .storyboard, .swift]
+        return [.h, .json, .m, .markdown, .mm, .pbxproj, .plist, .storyboard, .swift, .xcscheme, yaml, yml]
     }
 }
 

--- a/Sources/Danger/File.swift
+++ b/Sources/Danger/File.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+// MARK: - File
+
+/// A simple typealias for strings representing files
+public typealias File = String
+
+public extension File {
+    var fileType: FileType? {
+        return FileType(from: self)
+    }
+}
+
+// MARK: - FileType
+
+public enum FileType: String { // Try verticle version
+    case h
+    case json
+    case m
+    case markdown = "md"
+    case pbxproj
+    case plist
+    case storyboard
+    case swift
+}
+
+extension FileType {
+    
+    @available(swift, deprecated: 4.2, message: "Replace with CaseIterable conformance")
+    static internal var allCases: [FileType] {
+        return [.h, .json, .m, .markdown, .pbxproj, .plist, .storyboard, .swift]
+    }
+    
+    public var `extension`: String {
+        return rawValue
+    }
+    
+    public init?(from fileName: String) {
+        let allCasesDelimited = FileType.allCases.map { $0.extension }.joined(separator: "|")
+        
+        // TODO: move ugly regex stuff to tested extension where it belongs, write tests
+        guard
+            let regex = try? NSRegularExpression(pattern: "\\.(\(allCasesDelimited))$", options: []),
+            let match = regex.firstMatch(in: fileName, options: [], range: NSRange(location: 0, length: fileName.count)),
+            let range = Range(match.range, in: fileName)
+            else {
+                return nil
+        }
+        
+        let rawValue = String(fileName[range])
+        self.init(rawValue: rawValue)
+    }
+    
+}

--- a/Sources/Danger/File.swift
+++ b/Sources/Danger/File.swift
@@ -10,12 +10,16 @@ extension File {
     public var fileType: FileType? {
         return FileType(from: self)
     }
+    
+    public var name: String {
+        return String(self)
+    }
 
 }
 
 // MARK: - FileType
 
-public enum FileType: String {
+public enum FileType: String, Equatable {
     case h, json, m, markdown = "md", pbxproj, plist, storyboard, swift
 
     @available(swift, deprecated: 4.2, message: "Replace with CaseIterable conformance")
@@ -32,16 +36,17 @@ extension FileType {
         return rawValue
     }
 
-    public init?(from fileName: String) {
+    public init?(from file: File) {
         let allCasesDelimited = FileType.allCases.map { $0.extension }.joined(separator: "|")
 
         guard
             let pattern = try? NSRegularExpression(pattern: "\\.(\(allCasesDelimited))$"),
-            let rawValue = pattern.firstMatchingString(in: fileName)
+            let match = pattern.firstMatchingString(in: file.name)
         else {
             return nil
         }
-
+        
+        let rawValue = match.replacingOccurrences(of: ".", with: "")
         self.init(rawValue: rawValue)
     }
 

--- a/Sources/Danger/File.swift
+++ b/Sources/Danger/File.swift
@@ -5,50 +5,47 @@ import Foundation
 /// A simple typealias for strings representing files
 public typealias File = String
 
-public extension File {
-    var fileType: FileType? {
+extension File {
+
+    public var fileType: FileType? {
         return FileType(from: self)
     }
+
 }
 
 // MARK: - FileType
 
-public enum FileType: String { // Try verticle version
-    case h
-    case json
-    case m
-    case markdown = "md"
-    case pbxproj
-    case plist
-    case storyboard
-    case swift
-}
+public enum FileType: String {
+    case h, json, m, markdown = "md", pbxproj, plist, storyboard, swift
 
-extension FileType {
-    
     @available(swift, deprecated: 4.2, message: "Replace with CaseIterable conformance")
     static internal var allCases: [FileType] {
         return [.h, .json, .m, .markdown, .pbxproj, .plist, .storyboard, .swift]
     }
-    
+}
+
+// MARK: - Public extensions
+
+extension FileType {
+
     public var `extension`: String {
         return rawValue
     }
-    
+
     public init?(from fileName: String) {
         let allCasesDelimited = FileType.allCases.map { $0.extension }.joined(separator: "|")
-        
+
         // TODO: move ugly regex stuff to tested extension where it belongs, write tests
         guard
             let regex = try? NSRegularExpression(pattern: "\\.(\(allCasesDelimited))$", options: []),
             let match = regex.firstMatch(in: fileName, options: [], range: NSRange(location: 0, length: fileName.count)),
             let range = Range(match.range, in: fileName)
-            else {
-                return nil
+        else {
+            return nil
         }
-        
+
         let rawValue = String(fileName[range])
         self.init(rawValue: rawValue)
     }
-    
+
 }

--- a/Sources/Danger/GitDSL.swift
+++ b/Sources/Danger/GitDSL.swift
@@ -16,13 +16,13 @@ public struct Git: Decodable, Equatable {
     // MARK: - Properties
 
     /// Modified filepaths relative to the git root.
-    public let modifiedFiles: [String]
+    public let modifiedFiles: [File]
 
     /// Newly created filepaths relative to the git root.
-    public let createdFiles: [String]
+    public let createdFiles: [File]
 
     /// Removed filepaths relative to the git root.
-    public let deletedFiles: [String]
+    public let deletedFiles: [File]
 
 }
 

--- a/Tests/DangerTests/FileTests.swift
+++ b/Tests/DangerTests/FileTests.swift
@@ -8,10 +8,14 @@ class FileTests: XCTestCase {
         ("test_fileType_forJSON", test_fileType_forJSON),
         ("test_fileType_forM", test_fileType_forM),
         ("test_fileType_forMarkdown", test_fileType_forMarkdown),
+        ("test_fileType_forMM", test_fileType_forMM),
         ("test_fileType_forPbxproj", test_fileType_forPbxproj),
         ("test_fileType_forPlist", test_fileType_forPlist),
         ("test_fileType_forStoryboard", test_fileType_forStoryboard),
         ("test_fileType_forSwift", test_fileType_forSwift),
+        ("test_fileType_forXCScheme", test_fileType_forXCScheme),
+        ("test_fileType_forYAML", test_fileType_forYAML),
+        ("test_fileType_forYML", test_fileType_forYML),
     ]
     
     func test_fileType_forHFile() {
@@ -53,6 +57,16 @@ class FileTests: XCTestCase {
         XCTAssertEqual(file.fileType, expectedType)
         XCTAssertNil(unknownFile.fileType)
     }
+    
+    func test_fileType_forMM() {
+        let file: File = "CoreLib.mm"
+        let unknownFile: File = "CoreLib.mmm"
+        
+        let expectedType: FileType = .mm
+        
+        XCTAssertEqual(file.fileType, expectedType)
+        XCTAssertNil(unknownFile.fileType)
+    }
 
     func test_fileType_forPbxproj() {
         let file: File = "project.pbxproj"
@@ -89,6 +103,36 @@ class FileTests: XCTestCase {
         let unknownFile: File = "ViewController.swiftz"
         
         let expectedType: FileType = .swift
+        
+        XCTAssertEqual(file.fileType, expectedType)
+        XCTAssertNil(unknownFile.fileType)
+    }
+    
+    func test_fileType_forXCScheme() {
+        let file: File = "project.xcscheme"
+        let unknownFile: File = "project.xcschemes"
+        
+        let expectedType: FileType = .xcscheme
+        
+        XCTAssertEqual(file.fileType, expectedType)
+        XCTAssertNil(unknownFile.fileType)
+    }
+    
+    func test_fileType_forYAML() {
+        let file: File = "config.yaml"
+        let unknownFile: File = "config.yamll"
+        
+        let expectedType: FileType = .yaml
+        
+        XCTAssertEqual(file.fileType, expectedType)
+        XCTAssertNil(unknownFile.fileType)
+    }
+    
+    func test_fileType_forYML() {
+        let file: File = ".swiftlint.yml"
+        let unknownFile: File = ".swiftlint.ymll"
+        
+        let expectedType: FileType = .yml
         
         XCTAssertEqual(file.fileType, expectedType)
         XCTAssertNil(unknownFile.fileType)

--- a/Tests/DangerTests/FileTests.swift
+++ b/Tests/DangerTests/FileTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import Danger
+
+class FileTests: XCTestCase {
+    
+    static var allTests = [
+        ("test_fileType_forHFile", test_fileType_forHFile),
+        ("test_fileType_forJSON", test_fileType_forJSON),
+        ("test_fileType_forM", test_fileType_forM),
+        ("test_fileType_forMarkdown", test_fileType_forMarkdown),
+        ("test_fileType_forPbxproj", test_fileType_forPbxproj),
+        ("test_fileType_forPlist", test_fileType_forPlist),
+        ("test_fileType_forStoryboard", test_fileType_forStoryboard),
+        ("test_fileType_forSwift", test_fileType_forSwift),
+    ]
+    
+    func test_fileType_forHFile() {
+        let file: File = "bridging-header.h"
+        let unknownFile: File = "bridging-header.hm"
+        
+        let expectedType: FileType = .h
+        
+        XCTAssertEqual(file.fileType, expectedType)
+        XCTAssertNil(unknownFile.fileType)
+    }
+    
+    func test_fileType_forJSON() {
+        let file: File = "test_data.json"
+        let unknownFile: File = "test_data.jsonn"
+        
+        let expectedType: FileType = .json
+        
+        XCTAssertEqual(file.fileType, expectedType)
+        XCTAssertNil(unknownFile.fileType)
+    }
+    
+    func test_fileType_forM() {
+        let file: File = "ViewController.m"
+        let unknownFile: File = "ViewController.mk"
+        
+        let expectedType: FileType = .m
+        
+        XCTAssertEqual(file.fileType, expectedType)
+        XCTAssertNil(unknownFile.fileType)
+    }
+
+    func test_fileType_forMarkdown() {
+        let file: File = "README.md"
+        let unknownFile: File = "README.mda"
+        
+        let expectedType: FileType = .markdown
+        
+        XCTAssertEqual(file.fileType, expectedType)
+        XCTAssertNil(unknownFile.fileType)
+    }
+
+    func test_fileType_forPbxproj() {
+        let file: File = "project.pbxproj"
+        let unknownFile: File = "project.pbxproject"
+        
+        let expectedType: FileType = .pbxproj
+        
+        XCTAssertEqual(file.fileType, expectedType)
+        XCTAssertNil(unknownFile.fileType)
+    }
+    
+    func test_fileType_forPlist() {
+        let file: File = "info.plist"
+        let unknownFile: File = "info.plists"
+        
+        let expectedType: FileType = .plist
+        
+        XCTAssertEqual(file.fileType, expectedType)
+        XCTAssertNil(unknownFile.fileType)
+    }
+    
+    func test_fileType_forStoryboard() {
+        let file: File = "ViewController.storyboard"
+        let unknownFile: File = "ViewController.storyboards"
+        
+        let expectedType: FileType = .storyboard
+        
+        XCTAssertEqual(file.fileType, expectedType)
+        XCTAssertNil(unknownFile.fileType)
+    }
+    
+    func test_fileType_forSwift() {
+        let file: File = "ViewController.swift"
+        let unknownFile: File = "ViewController.swiftz"
+        
+        let expectedType: FileType = .swift
+        
+        XCTAssertEqual(file.fileType, expectedType)
+        XCTAssertNil(unknownFile.fileType)
+    }
+}

--- a/Tests/DangerTests/FileTypeTests.swift
+++ b/Tests/DangerTests/FileTypeTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import Danger
+
+import XCTest
+
+class FileTypeTests: XCTestCase {
+    
+    static var allTests = [
+        ("test_extension_matchesRawValue", test_extension_matchesRawValue),
+    ]
+
+    func test_extension_matchesRawValue() {
+        FileType.allCases.forEach { type in
+            XCTAssertEqual(type.extension, type.rawValue)
+        }
+    }
+    
+}

--- a/Tests/DangerTests/NSRegularExpressionExtensionsTests.swift
+++ b/Tests/DangerTests/NSRegularExpressionExtensionsTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import Danger
+
+class NSRegularExpressionExtensionsTests: XCTestCase {
+    
+    static var allTests = [
+        ("test_firstMatchingString_passingRegex", test_firstMatchingString_passingRegex),
+        ("test_firstMatchingString_failingRegex", test_firstMatchingString_failingRegex)
+    ]
+    
+    let string = "Dogs and cats were wearing hats"
+    
+    func test_firstMatchingString_passingRegex() {
+        let pattern = "(cats|hats)$"
+        let expectedMatch = "hats"
+        
+        guard
+            let expression = try? NSRegularExpression(pattern: pattern),
+            let testMatch = expression.firstMatchingString(in: string)
+        else {
+            XCTFail(); return
+        }
+        
+        XCTAssertEqual(testMatch, expectedMatch)
+    }
+    
+    func test_firstMatchingString_failingRegex() {
+        let pattern = "^(cats|hats)"
+        
+        guard let expression = try? NSRegularExpression(pattern: pattern) else {
+                XCTFail(); return
+        }
+        
+        let testMatch = expression.firstMatchingString(in: string)
+        
+        XCTAssertNil(testMatch)
+    }
+    
+}


### PR DESCRIPTION
As per [#80](https://github.com/danger/danger-swift/issues/80), I propose to change modifiedFiles, createdFiles, and deletedFiles to be of type `File` from String, adding Name and FileType properties. 

This will break some Dangerfile workflow, requiring users to potentially have to access the .name property to get a regular string. In return, users a get type-safe enum property called fileType for .h, .json, .m, .markdown, .mm, .pbxproj, .plist, .storyboard, .swift, .xcscheme, .yaml, .yml. 

In Ruby, detecting the filetype is rather straightforward because of easy-to-use regex support built right in. Swift, on the other hand, would require users to use the clunky NSRegularExpression class, which is bothersome to do inside the Dangerfile. 

### Example of use in Dangerfile
```swift
import Danger

let codeWasModified = git.modifiedFiles
    .filter { $0.fileType == .swift || $0.fileType == .m  || $0.fileType == .h }
    .count > 0

let changelogWasModified == git.modifiedFiles
    .filter { $0.name == "Changelog.md" }
    .count > 0

if codeWasModified && !changelogWasModified {
    warn("Please update the changelog")
}
```