### PR TITLE
Supports using the new url option for sub-processes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
       osx_image: xcode10
       install:
         - node -v
-        - npm install -g danger@beta
+        - npm install -g danger
         - swift build
       script:
         - swift test
@@ -19,7 +19,7 @@ matrix:
       dist: trusty
       install:
         - node -v
-        - npm install -g danger@beta
+        - npm install -g danger
         - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
         - swiftenv global 4.2
         - swift build

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
       osx_image: xcode10
       install:
         - node -v
-        - npm install -g danger
+        - npm install -g danger@beta
         - swift build
       script:
         - swift test
@@ -19,7 +19,7 @@ matrix:
       dist: trusty
       install:
         - node -v
-        - npm install -g danger
+        - npm install -g danger@beta
         - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
         - swiftenv global 4.2
         - swift build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## Master
 
+* Prepares for Danger JS 5.0 - [#84](https://github.com/danger/danger-swift/pull/84) by [orta](https://github.com/orta)
+
 ## 0.4.1
 
 * Use CaseIterable to take advantage of compiler-generated `allCases` in enum by [yhkaplan](https://github.com/yhkaplan) (requires Swift 4.2)

--- a/Sources/Runner/Commands/Runner.swift
+++ b/Sources/Runner/Commands/Runner.swift
@@ -123,15 +123,6 @@ func runDanger(logger: Logger) throws -> Void {
 
     // Support the upcoming danger results-url
     standardOutput.write("danger-results:/\(dangerResponsePath)".data(using: .utf8)!)
-    // Blank line just to make sure the json has
-    standardOutput.write("\n\n".data(using: .utf8)!)
-    standardOutput.synchronizeFile()
-
-    // Take JSON and pipe it back to SDTOUT for DangerJS to read
-    standardOutput.write(results)
-
-
-    standardOutput.write("\n\n".data(using: .utf8)!)
 
     // Clean up after ourselves
     try? fileManager.removeItem(atPath: dslJSONPath)

--- a/Sources/Runner/Commands/Runner.swift
+++ b/Sources/Runner/Commands/Runner.swift
@@ -121,8 +121,15 @@ func runDanger(logger: Logger) throws -> Void {
         exit(1)
     }
 
+    // Support the upcoming danger results-url
+    standardOutput.write("danger-results:/\(dangerResponsePath)".data(using: .utf8)!)
+    // Blank line just to make sure the json has
+    standardOutput.write("\n\n".data(using: .utf8)!)
+
     // Take JSON and pipe it back to SDTOUT for DangerJS to read
     standardOutput.write(results)
+
+    standardOutput.write("\n\n".data(using: .utf8)!)
 
     // Clean up after ourselves
     try? fileManager.removeItem(atPath: dslJSONPath)

--- a/Sources/Runner/Commands/Runner.swift
+++ b/Sources/Runner/Commands/Runner.swift
@@ -125,9 +125,11 @@ func runDanger(logger: Logger) throws -> Void {
     standardOutput.write("danger-results:/\(dangerResponsePath)".data(using: .utf8)!)
     // Blank line just to make sure the json has
     standardOutput.write("\n\n".data(using: .utf8)!)
+    standardOutput.synchronizeFile()
 
     // Take JSON and pipe it back to SDTOUT for DangerJS to read
     standardOutput.write(results)
+
 
     standardOutput.write("\n\n".data(using: .utf8)!)
 

--- a/Sources/Runner/Commands/Runner.swift
+++ b/Sources/Runner/Commands/Runner.swift
@@ -133,7 +133,6 @@ func runDanger(logger: Logger) throws -> Void {
 
     // Clean up after ourselves
     try? fileManager.removeItem(atPath: dslJSONPath)
-    try? fileManager.removeItem(atPath: dangerResponsePath)
 
     // Return the same error code as the compilation
     exit(proc.terminationStatus)

--- a/Sources/Runner/main.swift
+++ b/Sources/Runner/main.swift
@@ -3,7 +3,7 @@ import Danger
 
 let cliLength = ProcessInfo.processInfo.arguments.count
 do {
-    let isVerbose = CommandLine.arguments.contains("--verbose")
+    let isVerbose = CommandLine.arguments.contains("--verbose") || ProcessInfo.processInfo.environment["DEBUG"] != nil
     let isSilent = CommandLine.arguments.contains("--silent")
     let logger = Logger(isVerbose: isVerbose, isSilent: isSilent)
     if cliLength > 1 && "edit" == CommandLine.arguments[1] {


### PR DESCRIPTION
This should fix https://github.com/danger/danger-swift/issues/69 - but it requires shipping Danger JS 5.0 

For now this is both backwards and future compatible on both sides, as it does both the url and the json and Danger JS supports listening for both the url and the JSON (but prioritizes the URL)

Docs will be shipped on the danger systems page for `danger process`.