### PR TITLE
 Expose Danger report results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Master
 
+* Expose Danger report results - [#89](https://github.com/danger/danger-swift/pull/89) by [f-meloni](https://github.com/f-meloni)
 - Adds two new commands: 
     - `danger-swift ci` - handles running Danger
     - `danger-swift pr [https://github.com/Moya/Harvey/pull/23]` - Let's you run Danger against a PR locally

--- a/Sources/Danger/Danger.swift
+++ b/Sources/Danger/Danger.swift
@@ -63,6 +63,26 @@ public func Danger() -> DangerDSL {
     return DangerRunner.shared.dsl
 }
 
+/// Fails on the Danger report
+public var fails: [Violation] {
+    return DangerRunner.shared.results.fails
+}
+
+/// Warnings on the Danger report
+public var warnings: [Violation] {
+    return DangerRunner.shared.results.warnings
+}
+
+/// Messages on the Danger report
+public var messages: [Violation] {
+    return DangerRunner.shared.results.messages
+}
+
+/// Markdowns on the Danger report
+public var markdowns: [Violation] {
+    return DangerRunner.shared.results.markdowns
+}
+
 /// Adds a warning message to the Danger report
 ///
 /// - Parameter message: A markdown-ish

--- a/Sources/Danger/DangerResults.swift
+++ b/Sources/Danger/DangerResults.swift
@@ -3,7 +3,7 @@ import Foundation
 // MARK: - Violation
 
 /// The result of a warn, message, or fail.
-struct Violation: Codable {
+public struct Violation: Codable {
 
     let message: String
     let file: String?


### PR DESCRIPTION
I thought it would be valuable to allow who is writing the Dangerfile to access the current report results.
An example of usage could be the ruby LGTM plugin that uses it to understand if show or not the LGTM image. https://github.com/leonhartX/danger-lgtm/blob/master/lib/lgtm/plugin.rb#L33